### PR TITLE
Add support for templated gql strings in typescript files

### DIFF
--- a/src/typescript/mod.rs
+++ b/src/typescript/mod.rs
@@ -22,6 +22,8 @@ pub enum Error {
     UnionOnlyAllowedTypename(String),
     UnionCanOnlyHaveObjectImplementors,
     MissingType(String),
+    // TODO: remove from here
+    NoMatchingQueryDelimitor(String),
     NotGlobalType(String),
     UnknownField(String, String),
     UnknownFragment(String),

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -51,6 +51,20 @@ pub fn basic_success_assert(
     assert_generated(&temp_dir, expected_file_name, expected_content);
 }
 
+pub fn basic_success_assert_typescript(
+    typescript_content: &str,
+    expected_file_name: &str,
+    expected_content: &'static str,
+) {
+    let (mut cmd, temp_dir) = qlc_command_with_fake_dir_and_schema();
+    temp_dir
+        .child("file.ts")
+        .write_str(typescript_content)
+        .unwrap();
+    cmd.assert().success();
+    assert_generated(&temp_dir, expected_file_name, expected_content);
+}
+
 /// Same as `basic_success_assert` but asserts a global types file as well
 pub fn basic_success_with_global_types_assert(
     graphql_content: &str,

--- a/tests/typescript/mod.rs
+++ b/tests/typescript/mod.rs
@@ -4,6 +4,7 @@ mod complex;
 mod enumeration;
 mod field;
 mod variable;
+mod parse_gql_tags;
 
 #[test]
 fn compile_simple_query() {

--- a/tests/typescript/parse_gql_tags.rs
+++ b/tests/typescript/parse_gql_tags.rs
@@ -1,0 +1,40 @@
+use crate::helpers::basic_success_assert_typescript;
+
+#[test]
+fn compile_simple_query() {
+    basic_success_assert_typescript(
+r"
+const query = gql`
+    query TestQuery {
+        viewer {
+            id
+            me: user {
+                id
+            }
+        }
+    }
+`;
+",
+    "TestQuery.ts",
+    "
+export interface TestQuery_viewer_me {
+  id: string;
+}
+
+export interface TestQuery_viewer {
+  id: string;
+  /**
+   * The user associated with the current viewer. Use this field to get info
+   * about current viewer and access any records associated w/ their account.
+   */
+  me: TestQuery_viewer_me | null;
+}
+
+export interface TestQuery {
+  /**
+   * Access to fields relevant to a consumer of the application
+   */
+  viewer: TestQuery_viewer | null;
+}
+    ")
+}


### PR DESCRIPTION
This PR adds support for generating interfaces from templated gql strings in typescript files.

> The usecase is the same for almost every apollo + angular user as nobody really tries to fiddle with the webpack configuration to import graphql files from typescript.

The code is really ugly, I just tried to make it work as I navigated through the codebase for the first time. 

I'd be glad to take any feedback and make required changes :)

**TODO**
- [ ] Support for fragment
- [ ] Clean up code + move for better separation of concerns
- [ ] Add tests (also move them)
- [ ] Better typescript parsing
- [ ] CLI flag not to slow down everyone