### PR TITLE
Version 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.2.0](https://github.com/notarize/qlc/compare/2.1.0...2.2.0)
+
+### Features
+
+- Fields deprecated in the schema are marked with `@deprecated` JSDoc
+- "Variables" types now have sorted property names
+
+### Bugfixes
+
+- Fix an issue with root imports when `--root-dir-import-prefix` is empty string
+
 ## [2.1.0](https://github.com/notarize/qlc/compare/2.0.0...2.1.0)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "qlc"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qlc"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Eric Kim-Butler <eric.butler@notarize.com>"]
 edition = "2021"
 license = "MIT"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -435,7 +435,7 @@ pub struct RuntimeConfig {
     use_custom_scalars: bool,
     custom_scalar_prefix: Option<String>,
     number_threads: usize,
-    root_dir_import_prefix: String,
+    root_dir_import_prefix: Option<String>,
     global_types_module_name: String,
     generated_module_name: String,
 }
@@ -490,8 +490,7 @@ impl RuntimeConfig {
         let root_dir_import_prefix = arg_matches
             .value_of("root_dir_import_prefix")
             .map(|s| s.to_string())
-            .or(config_root_dir_import_prefix)
-            .unwrap_or_else(|| String::from(""));
+            .or(config_root_dir_import_prefix);
         let global_types_module_name = arg_matches
             .value_of("global_types_module_name")
             .map(|s| s.to_string())
@@ -540,7 +539,7 @@ impl RuntimeConfig {
         self.number_threads
     }
 
-    pub fn root_dir_import_prefix(&self) -> String {
+    pub fn root_dir_import_prefix(&self) -> Option<String> {
         self.root_dir_import_prefix.clone()
     }
 

--- a/src/graphql/ir.rs
+++ b/src/graphql/ir.rs
@@ -274,6 +274,7 @@ impl<'a> TryFrom<UniqueFields<'a>> for Vec<Field> {
                 Ok(Field {
                     prop_name: alias.to_string(),
                     documentation: field.documentation.clone(),
+                    deprecated: field.deprecated,
                     last_type_modifier: field.type_description.type_modifiers().1.clone(),
                     type_ir: get_type_ir_for_field(field, concrete, sub_traversal)?,
                 })
@@ -460,6 +461,7 @@ impl<'a> FieldTraversal<'a> {
 pub struct Field {
     pub prop_name: String,
     pub documentation: schema::Documentation,
+    pub deprecated: bool,
     pub last_type_modifier: schema_field::FieldTypeModifier,
     pub type_ir: FieldType,
 }

--- a/src/typescript.rs
+++ b/src/typescript.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet};
 
 mod field;
 
+const EMPTY: &str = "";
 const HEADER: &str = "/* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -238,10 +239,12 @@ fn compile_documentation(documentation: &schema::Documentation, tab_width: usize
         .as_ref()
         .map(|docs| {
             let tab = " ".repeat(tab_width);
-            let processed_desc = docs.replace('\n', &format!("\n {tab}* ")).replace("*/", "");
+            let processed_desc = docs
+                .replace('\n', &format!("\n {tab}* "))
+                .replace("*/", EMPTY);
             format!("/**\n {tab}* {processed_desc}\n {tab}*/\n{tab}")
         })
-        .unwrap_or_else(|| String::from(""))
+        .unwrap_or_else(|| String::from(EMPTY))
 }
 
 fn compile_custom_scalar_name(
@@ -431,7 +434,7 @@ fn compile_variables_type_definition(
     op_ir: &ir::Operation<'_>,
 ) -> Result<Typescript> {
     match op_ir.variables {
-        None => Ok("".to_string()),
+        None => Ok(EMPTY.to_string()),
         Some(ref var_irs) => {
             let prop_defs: Result<Vec<_>> = var_irs
                 .iter()
@@ -485,7 +488,7 @@ fn compile_variables_type_definition(
 
 fn compile_imports(config: &CompileConfig, used_globals: &HashSet<String>) -> Typescript {
     if used_globals.is_empty() {
-        return String::from("");
+        return String::from(EMPTY);
     }
     // For test and file signature stability
     let mut sorted_names: Vec<&str> = used_globals.iter().map(|g| g.as_ref()).collect();
@@ -493,7 +496,7 @@ fn compile_imports(config: &CompileConfig, used_globals: &HashSet<String>) -> Ty
     format!(
         "import type {{ {} }} from \"{}{}/{}\";\n\n",
         sorted_names.join(", "),
-        config.root_dir_import_prefix,
+        config.root_dir_import_prefix.as_deref().unwrap_or(EMPTY),
         config.generated_module_name,
         config.global_types_module_name,
     )

--- a/tests/typescript/field.rs
+++ b/tests/typescript/field.rs
@@ -136,3 +136,79 @@ export type TestQuery = {
         ",
     );
 }
+
+#[test]
+fn compile_deprecated_field() {
+    let (mut cmd, temp_dir) = qlc_command_with_fake_dir_and_schema();
+    temp_dir
+        .child("file.graphql")
+        .write_str(
+            "
+query Deprecated($orgId: ID!) {
+  viewer {
+    user {
+      tier
+    }
+  }
+  org: node(id: $orgId) {
+    ... on Organization {
+      features
+    }
+  }
+}
+            ",
+        )
+        .unwrap();
+    cmd.assert().success();
+    assert_generated(
+        &temp_dir,
+        "Deprecated.ts",
+        r#"
+import type { OrganizationAvailableFeatures, Tier } from "__generated__/globalTypes";
+
+export type Deprecated_org_Organization = {
+  /**
+   * Features available for the organization to use (from LaunchDarkly)
+   * @deprecated
+   */
+  features: (OrganizationAvailableFeatures | null)[] | null;
+};
+
+export type Deprecated_org_$$other = {
+
+};
+
+export type Deprecated_org = Deprecated_org_Organization | Deprecated_org_$$other;
+
+export type Deprecated_viewer_user = {
+  /**
+   * @deprecated
+   */
+  tier: Tier;
+};
+
+export type Deprecated_viewer = {
+  /**
+   * The user associated with the current viewer. Use this field to get info
+   * about current viewer and access any records associated w/ their account.
+   */
+  user: Deprecated_viewer_user | null;
+};
+
+export type Deprecated = {
+  /**
+   * Fetches an object given its ID.
+   */
+  org: Deprecated_org | null;
+  /**
+   * Access to fields relevant to a consumer of the application
+   */
+  viewer: Deprecated_viewer | null;
+};
+
+export type DeprecatedVariables = {
+  orgId: string;
+};
+        "#,
+    );
+}


### PR DESCRIPTION
* Sort property names in "Variables" Types for more deterministic output
* Add `@deprecated` to fields marked as such in the schema
* Fix a module resolution bug when `root_dir_import_prefix` is `""`