### PR TITLE
Various Feature Improvements

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -318,6 +318,11 @@ fn arg_parse() -> ArgMatches {
                 .help("Use custom schema defined scalar names for types instead of any type"),
         )
         .arg(
+            Arg::new("disable_readonly_types")
+                .long("disable-readonly-types")
+                .help("Disable marking types as readonly"),
+        )
+        .arg(
             Arg::new("custom_scalar_prefix")
                 .takes_value(true)
                 .value_name("PREFIX")
@@ -374,6 +379,8 @@ struct ConfigFileMatches {
     schema_path: Option<PathBuf>,
     #[serde(rename(deserialize = "useCustomScalars"))]
     use_custom_scalars: Option<bool>,
+    #[serde(rename(deserialize = "disableReadonlyTypes"))]
+    disable_readonly_types: Option<bool>,
     #[serde(rename(deserialize = "customScalarPrefix"))]
     custom_scalar_prefix: Option<String>,
     #[serde(rename(deserialize = "numThreads"))]
@@ -433,6 +440,7 @@ pub struct RuntimeConfig {
     schema_path: PathBuf,
     show_deprecation_warnings: bool,
     use_custom_scalars: bool,
+    disable_readonly_types: bool,
     custom_scalar_prefix: Option<String>,
     number_threads: usize,
     root_dir_import_prefix: Option<String>,
@@ -457,6 +465,7 @@ impl RuntimeConfig {
             root_dir_import_prefix: config_root_dir_import_prefix,
             global_types_module_name: config_global_types_module_name,
             generated_module_name: config_generated_module_name,
+            disable_readonly_types: config_disable_readonly_types,
         } = match ConfigFileMatches::from_file_parse(arg_matches.value_of("config_file_path")) {
             Ok(matches) => matches,
             Err(config_error_message) => {
@@ -478,6 +487,8 @@ impl RuntimeConfig {
             || config_show_deprecation_warnings.unwrap_or(false);
         let use_custom_scalars = arg_matches.is_present("use_custom_scalars")
             || config_use_custom_scalars.unwrap_or(false);
+        let disable_readonly_types = arg_matches.is_present("disable_readonly_types")
+            || config_disable_readonly_types.unwrap_or(false);
         let custom_scalar_prefix = arg_matches
             .value_of("custom_scalar_prefix")
             .map(|s| s.to_string())
@@ -507,6 +518,7 @@ impl RuntimeConfig {
             schema_path,
             show_deprecation_warnings,
             use_custom_scalars,
+            disable_readonly_types,
             custom_scalar_prefix,
             number_threads,
             root_dir_import_prefix,
@@ -549,6 +561,10 @@ impl RuntimeConfig {
 
     pub fn generated_module_name(&self) -> String {
         self.generated_module_name.clone()
+    }
+
+    pub fn disable_readonly_types(&self) -> bool {
+        self.disable_readonly_types
     }
 }
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -32,6 +32,7 @@ pub enum BottomTypeConfig {
 pub struct CompileConfig {
     root_dir: PathBuf,
     show_deprecation_warnings: bool,
+    pub use_readonly_types: bool,
     pub bottom_type_config: BottomTypeConfig,
     pub root_dir_import_prefix: Option<String>,
     pub global_types_module_name: String,
@@ -42,6 +43,7 @@ impl From<&RuntimeConfig> for CompileConfig {
     fn from(from: &RuntimeConfig) -> Self {
         CompileConfig {
             root_dir: from.root_dir_path(),
+            use_readonly_types: !from.disable_readonly_types(),
             bottom_type_config: from.bottom_type_config(),
             show_deprecation_warnings: from.show_deprecation_warnings(),
             root_dir_import_prefix: from.root_dir_import_prefix(),

--- a/src/graphql/ir.rs
+++ b/src/graphql/ir.rs
@@ -275,7 +275,7 @@ impl<'a> TryFrom<UniqueFields<'a>> for Vec<Field> {
                     prop_name: alias.to_string(),
                     documentation: field.documentation.clone(),
                     deprecated: field.deprecated,
-                    last_type_modifier: field.type_description.type_modifiers().1.clone(),
+                    type_modifiers: field.type_description.type_modifiers(),
                     type_ir: get_type_ir_for_field(field, concrete, sub_traversal)?,
                 })
             })
@@ -462,7 +462,7 @@ pub struct Field {
     pub prop_name: String,
     pub documentation: schema::Documentation,
     pub deprecated: bool,
-    pub last_type_modifier: schema_field::FieldTypeModifier,
+    pub type_modifiers: schema_field::FieldTypeModifiers,
     pub type_ir: FieldType,
 }
 

--- a/src/typescript.rs
+++ b/src/typescript.rs
@@ -425,8 +425,13 @@ fn type_definitions_from_complex_ir<'a>(
         };
         let prop_def_type = prop_type_def(&field_ir.last_type_modifier, flat_type_name);
         let doc_comment = compile_documentation(&field_ir.documentation, field_ir.deprecated, 2);
+        let readonly_modifier = if config.use_readonly_types {
+            "readonly "
+        } else {
+            EMPTY
+        };
         prop_defs.push(format!(
-            "  {doc_comment}{}: {prop_def_type};",
+            "  {doc_comment}{readonly_modifier}{}: {prop_def_type};",
             field_ir.prop_name,
         ));
     }

--- a/src/typescript.rs
+++ b/src/typescript.rs
@@ -10,8 +10,7 @@ use std::collections::{HashMap, HashSet};
 mod field;
 
 const EMPTY: &str = "";
-const HEADER: &str = "/* tslint:disable */
-/* eslint-disable */
+const HEADER: &str = "/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 ";

--- a/src/typescript.rs
+++ b/src/typescript.rs
@@ -98,8 +98,7 @@ fn input_def_from_type(
     for (name, field) in sorted.into_iter() {
         let doc = compile_documentation(&field.documentation, field.deprecated, 2);
         let field_type = from_input_def_field_def(config, name, field)?;
-        let (_, last_type_mod) = field.type_description.type_modifiers();
-        let ts_field = match last_type_mod {
+        let ts_field = match field.type_description.type_modifiers().last() {
             schema_field::FieldTypeModifier::None => format!("  {doc}{name}: {field_type};"),
             schema_field::FieldTypeModifier::Nullable => {
                 format!("  {doc}{name}?: {field_type} | null;")
@@ -277,20 +276,32 @@ fn type_name_from_scalar(config: &CompileConfig, scalar: &schema_field::ScalarTy
     }
 }
 
-fn prop_type_def(
+fn single_prop_type_def(
     type_modifier: &schema_field::FieldTypeModifier,
-    flat_type_name: String,
-) -> String {
+    inner_type_name: Typescript,
+) -> Typescript {
     match type_modifier {
-        schema_field::FieldTypeModifier::None => flat_type_name,
-        schema_field::FieldTypeModifier::Nullable => format!("{flat_type_name} | null"),
-        schema_field::FieldTypeModifier::List => format!("{flat_type_name}[]"),
-        schema_field::FieldTypeModifier::NullableList => format!("{flat_type_name}[] | null"),
-        schema_field::FieldTypeModifier::ListOfNullable => format!("({flat_type_name} | null)[]"),
+        schema_field::FieldTypeModifier::None => inner_type_name,
+        schema_field::FieldTypeModifier::Nullable => format!("{inner_type_name} | null"),
+        schema_field::FieldTypeModifier::List => format!("{inner_type_name}[]"),
+        schema_field::FieldTypeModifier::NullableList => format!("{inner_type_name}[] | null"),
+        schema_field::FieldTypeModifier::ListOfNullable => format!("({inner_type_name} | null)[]"),
         schema_field::FieldTypeModifier::NullableListOfNullable => {
-            format!("({flat_type_name} | null)[] | null")
+            format!("({inner_type_name} | null)[] | null")
         }
     }
+}
+
+fn prop_type_def<'a>(
+    first_type_modifiers: impl Iterator<Item = &'a schema_field::FieldTypeModifier>,
+    last_type_modifier: &schema_field::FieldTypeModifier,
+    flat_type_name: Typescript,
+) -> Typescript {
+    let mut result = single_prop_type_def(last_type_modifier, flat_type_name);
+    for type_modifier in first_type_modifiers {
+        result = single_prop_type_def(type_modifier, format!("({result})"));
+    }
+    result
 }
 
 fn field_ids_for_complex_ir(complex: &ir::Complex) -> HashSet<&str> {
@@ -423,7 +434,11 @@ fn type_definitions_from_complex_ir<'a>(
             ir::FieldType::Scalar(scalar_type) => type_name_from_scalar(config, scalar_type),
             ir::FieldType::TypeName => format!("\"{}\"", complex_ir.name),
         };
-        let prop_def_type = prop_type_def(&field_ir.last_type_modifier, flat_type_name);
+        let prop_def_type = prop_type_def(
+            field_ir.type_modifiers.rest_modifiers_iter(),
+            field_ir.type_modifiers.last(),
+            flat_type_name,
+        );
         let doc_comment = compile_documentation(&field_ir.documentation, field_ir.deprecated, 2);
         let readonly_modifier = if config.use_readonly_types {
             "readonly "
@@ -484,7 +499,8 @@ fn compile_variables_type_definition<'a>(
                 .map(|var_ir| {
                     let type_name =
                         compile_variable_type_name(config, schema, global_types, var_ir)?;
-                    let type_def = prop_type_def(&var_ir.type_modifier, type_name);
+                    let type_def =
+                        prop_type_def(std::iter::empty(), &var_ir.type_modifier, type_name);
                     Ok((var_ir, type_def))
                 })
                 .collect::<Result<Vec<(&variable::Variable<'a>, String)>>>()

--- a/src/typescript.rs
+++ b/src/typescript.rs
@@ -132,13 +132,14 @@ fn enum_def_from_type(
     enum_type: &schema::EnumType,
 ) -> String {
     let doc_comment = compile_documentation(documentation, false, 0);
-    let values = enum_type
+    let mut sorted_values = enum_type
         .possible_values
         .iter()
         .map(|value| format!("  {value} = \"{value}\","))
-        .collect::<Vec<String>>()
-        .join("\n");
-    format!("{doc_comment}export enum {name} {{\n{values}\n}}")
+        .collect::<Vec<String>>();
+    sorted_values.sort_unstable();
+    let joined = sorted_values.join("\n");
+    format!("{doc_comment}export enum {name} {{\n{joined}\n}}")
 }
 
 fn add_sub_input_objects<'a>(

--- a/tests/fixtures/schema_generation/schema.graphql
+++ b/tests/fixtures/schema_generation/schema.graphql
@@ -87,6 +87,8 @@ type Network implements Node & Tagged {
   ipv6Cidr: String
   hosts(first: Int, last: Int): HostConnection!
   tags: [ResourceTag!]!
+  hostIdTopology: [[[ID]]]
+  hostIdGroups: [[ID!]!]!
 }
 
 "An OS makes hardware useful"

--- a/tests/fixtures/typescript/compile_simple_fragment/__generated__/SimpleFragment.ts
+++ b/tests/fixtures/typescript/compile_simple_fragment/__generated__/SimpleFragment.ts
@@ -1,13 +1,13 @@
 export type SimpleFragment_manager = {
-  firstName: string;
-  id: string;
+  readonly firstName: string;
+  readonly id: string;
 };
 
 export type SimpleFragment = {
-  email: string;
-  id: string;
+  readonly email: string;
+  readonly id: string;
   /**
    * A user's manager, if they have one
    */
-  manager: SimpleFragment_manager | null;
+  readonly manager: SimpleFragment_manager | null;
 };

--- a/tests/fixtures/typescript/compile_simple_mutation/__generated__/SimpleMutation.ts
+++ b/tests/fixtures/typescript/compile_simple_mutation/__generated__/SimpleMutation.ts
@@ -1,3 +1,3 @@
 export type SimpleMutation = {
-  decommissionHost: boolean;
+  readonly decommissionHost: boolean;
 };

--- a/tests/fixtures/typescript/compile_simple_query/__generated__/SimpleQuery.ts
+++ b/tests/fixtures/typescript/compile_simple_query/__generated__/SimpleQuery.ts
@@ -1,9 +1,9 @@
 export type SimpleQuery_me = {
-  firstName: string;
-  id: string;
-  last: string;
+  readonly firstName: string;
+  readonly id: string;
+  readonly last: string;
 };
 
 export type SimpleQuery = {
-  me: SimpleQuery_me | null;
+  readonly me: SimpleQuery_me | null;
 };

--- a/tests/fixtures/typescript/compile_simple_subscription/__generated__/SimpleSubscription.ts
+++ b/tests/fixtures/typescript/compile_simple_subscription/__generated__/SimpleSubscription.ts
@@ -1,9 +1,9 @@
 export type SimpleSubscription_me = {
-  firstName: string;
-  id: string;
-  last: string;
+  readonly firstName: string;
+  readonly id: string;
+  readonly last: string;
 };
 
 export type SimpleSubscription = {
-  me: SimpleSubscription_me | null;
+  readonly me: SimpleSubscription_me | null;
 };

--- a/tests/fixtures/typescript/compile_typename/__generated__/WithSomeDunderDunderTypename.ts
+++ b/tests/fixtures/typescript/compile_typename/__generated__/WithSomeDunderDunderTypename.ts
@@ -1,16 +1,16 @@
 export type WithSomeDunderDunderTypename_operator_personalHost = {
-  __typename: "Host";
-  id: string;
+  readonly __typename: "Host";
+  readonly id: string;
 };
 
 export type WithSomeDunderDunderTypename_operator = {
-  as: "User";
+  readonly as: "User";
   /**
    * A user's personal device
    */
-  personalHost: WithSomeDunderDunderTypename_operator_personalHost;
+  readonly personalHost: WithSomeDunderDunderTypename_operator_personalHost;
 };
 
 export type WithSomeDunderDunderTypename = {
-  operator: WithSomeDunderDunderTypename_operator | null;
+  readonly operator: WithSomeDunderDunderTypename_operator | null;
 };

--- a/tests/fixtures/typescript/compile_with_all_module_config/gen-me/RootCheck.ts
+++ b/tests/fixtures/typescript/compile_with_all_module_config/gen-me/RootCheck.ts
@@ -1,4 +1,4 @@
 export type RootCheck = {
-  id: string;
-  numCpus: number;
+  readonly id: string;
+  readonly numCpus: number;
 };

--- a/tests/fixtures/typescript/compile_with_all_module_config/gen-me/UsingModuleConfig.ts
+++ b/tests/fixtures/typescript/compile_with_all_module_config/gen-me/UsingModuleConfig.ts
@@ -1,19 +1,19 @@
 import type { OperatingSystem } from "~/gen-me/global-types";
 
 export type UsingModuleConfig_operator_personalHost = {
-  id: string;
-  numCpus: number;
-  operatingSystem: OperatingSystem;
+  readonly id: string;
+  readonly numCpus: number;
+  readonly operatingSystem: OperatingSystem;
 };
 
 export type UsingModuleConfig_operator = {
-  id: string;
+  readonly id: string;
   /**
    * A user's personal device
    */
-  personalHost: UsingModuleConfig_operator_personalHost;
+  readonly personalHost: UsingModuleConfig_operator_personalHost;
 };
 
 export type UsingModuleConfig = {
-  operator: UsingModuleConfig_operator | null;
+  readonly operator: UsingModuleConfig_operator | null;
 };

--- a/tests/fixtures/typescript/compile_with_all_module_config/gen-me/global-types.ts
+++ b/tests/fixtures/typescript/compile_with_all_module_config/gen-me/global-types.ts
@@ -3,6 +3,6 @@
  */
 export enum OperatingSystem {
   ARCH_LINUX = "ARCH_LINUX",
-  UBUNTU_LINUX = "UBUNTU_LINUX",
   FREEBSD = "FREEBSD",
+  UBUNTU_LINUX = "UBUNTU_LINUX",
 }

--- a/tests/fixtures/typescript/compile_with_all_module_config/lower/gen-me/LowerCheck.ts
+++ b/tests/fixtures/typescript/compile_with_all_module_config/lower/gen-me/LowerCheck.ts
@@ -1,13 +1,13 @@
 import type { OperatingSystem } from "~/gen-me/global-types";
 
 export type LowerCheck_personalHost = {
-  operatingSystem: OperatingSystem;
+  readonly operatingSystem: OperatingSystem;
 };
 
 export type LowerCheck = {
-  id: string;
+  readonly id: string;
   /**
    * A user's personal device
    */
-  personalHost: LowerCheck_personalHost;
+  readonly personalHost: LowerCheck_personalHost;
 };

--- a/tests/fixtures/typescript/complex/compile_absolute_import_fragments/__generated__/Root.ts
+++ b/tests/fixtures/typescript/complex/compile_absolute_import_fragments/__generated__/Root.ts
@@ -1,21 +1,21 @@
 import type { OperatingSystem } from "__generated__/globalTypes";
 
 export type Root_operator_personalHost = {
-  id: string;
-  osFromAbsolute: OperatingSystem;
-  personalHostIdFromRelative: string;
+  readonly id: string;
+  readonly osFromAbsolute: OperatingSystem;
+  readonly personalHostIdFromRelative: string;
 };
 
 export type Root_operator = {
-  email: string;
-  id: string;
-  lastNameFromRelative: string;
+  readonly email: string;
+  readonly id: string;
+  readonly lastNameFromRelative: string;
   /**
    * A user's personal device
    */
-  personalHost: Root_operator_personalHost;
+  readonly personalHost: Root_operator_personalHost;
 };
 
 export type Root = {
-  operator: Root_operator | null;
+  readonly operator: Root_operator | null;
 };

--- a/tests/fixtures/typescript/complex/compile_absolute_import_fragments/__generated__/globalTypes.ts
+++ b/tests/fixtures/typescript/complex/compile_absolute_import_fragments/__generated__/globalTypes.ts
@@ -3,6 +3,6 @@
  */
 export enum OperatingSystem {
   ARCH_LINUX = "ARCH_LINUX",
-  UBUNTU_LINUX = "UBUNTU_LINUX",
   FREEBSD = "FREEBSD",
+  UBUNTU_LINUX = "UBUNTU_LINUX",
 }

--- a/tests/fixtures/typescript/complex/compile_absolute_import_fragments/host/__generated__/AbsoluteFragmentHost.ts
+++ b/tests/fixtures/typescript/complex/compile_absolute_import_fragments/host/__generated__/AbsoluteFragmentHost.ts
@@ -1,5 +1,5 @@
 import type { OperatingSystem } from "__generated__/globalTypes";
 
 export type AbsoluteFragmentHost = {
-  osFromAbsolute: OperatingSystem;
+  readonly osFromAbsolute: OperatingSystem;
 };

--- a/tests/fixtures/typescript/complex/compile_absolute_import_fragments/user/__generated__/RelativeFragmentUser.ts
+++ b/tests/fixtures/typescript/complex/compile_absolute_import_fragments/user/__generated__/RelativeFragmentUser.ts
@@ -1,15 +1,15 @@
 import type { OperatingSystem } from "__generated__/globalTypes";
 
 export type RelativeFragmentUser_personalHost = {
-  osFromAbsolute: OperatingSystem;
-  personalHostIdFromRelative: string;
+  readonly osFromAbsolute: OperatingSystem;
+  readonly personalHostIdFromRelative: string;
 };
 
 export type RelativeFragmentUser = {
-  email: string;
-  lastNameFromRelative: string;
+  readonly email: string;
+  readonly lastNameFromRelative: string;
   /**
    * A user's personal device
    */
-  personalHost: RelativeFragmentUser_personalHost;
+  readonly personalHost: RelativeFragmentUser_personalHost;
 };

--- a/tests/fixtures/typescript/complex/compile_absolute_import_fragments/user/__generated__/SubUser.ts
+++ b/tests/fixtures/typescript/complex/compile_absolute_import_fragments/user/__generated__/SubUser.ts
@@ -1,3 +1,3 @@
 export type SubUser = {
-  email: string;
+  readonly email: string;
 };

--- a/tests/fixtures/typescript/complex/compile_deep_fragments/__generated__/DeeplyFragmented.ts
+++ b/tests/fixtures/typescript/complex/compile_deep_fragments/__generated__/DeeplyFragmented.ts
@@ -1,12 +1,12 @@
 export type DeeplyFragmented_operator = {
-  firstName: string;
-  id: string;
-  id2: string;
-  id3: string;
-  idDeep: string;
-  lastName: string;
+  readonly firstName: string;
+  readonly id: string;
+  readonly id2: string;
+  readonly id3: string;
+  readonly idDeep: string;
+  readonly lastName: string;
 };
 
 export type DeeplyFragmented = {
-  operator: DeeplyFragmented_operator | null;
+  readonly operator: DeeplyFragmented_operator | null;
 };

--- a/tests/fixtures/typescript/complex/compile_deep_fragments/__generated__/UserDeep.ts
+++ b/tests/fixtures/typescript/complex/compile_deep_fragments/__generated__/UserDeep.ts
@@ -1,4 +1,4 @@
 export type UserDeep = {
-  idDeep: string;
-  lastName: string;
+  readonly idDeep: string;
+  readonly lastName: string;
 };

--- a/tests/fixtures/typescript/complex/interface/compile_interface_abstract_only/__generated__/GetByNodeAbstractOnly.ts
+++ b/tests/fixtures/typescript/complex/interface/compile_interface_abstract_only/__generated__/GetByNodeAbstractOnly.ts
@@ -1,7 +1,7 @@
 export type GetByNodeAbstractOnly_host = {
-  id: string;
+  readonly id: string;
 };
 
 export type GetByNodeAbstractOnly = {
-  host: GetByNodeAbstractOnly_host | null;
+  readonly host: GetByNodeAbstractOnly_host | null;
 };

--- a/tests/fixtures/typescript/complex/interface/compile_interface_both_concrete_and_abstract/__generated__/GetSeveralNodesWithConcreteAndAbstract.ts
+++ b/tests/fixtures/typescript/complex/interface/compile_interface_both_concrete_and_abstract/__generated__/GetSeveralNodesWithConcreteAndAbstract.ts
@@ -1,39 +1,39 @@
 export type GetSeveralNodesWithConcreteAndAbstract_justHiredOperator_Network = {
-  __typename: "Network";
-  cidr: string;
-  id: string;
+  readonly __typename: "Network";
+  readonly cidr: string;
+  readonly id: string;
 };
 
 export type GetSeveralNodesWithConcreteAndAbstract_justHiredOperator_User = {
-  __typename: "User";
-  email: string;
-  firstName: string;
-  id: string;
-  lastName: string;
+  readonly __typename: "User";
+  readonly email: string;
+  readonly firstName: string;
+  readonly id: string;
+  readonly lastName: string;
 };
 
 export type GetSeveralNodesWithConcreteAndAbstract_justHiredOperator_$$other = {
-  __typename: "Host";
-  id: string;
+  readonly __typename: "Host";
+  readonly id: string;
 };
 
 export type GetSeveralNodesWithConcreteAndAbstract_justHiredOperator = GetSeveralNodesWithConcreteAndAbstract_justHiredOperator_Network | GetSeveralNodesWithConcreteAndAbstract_justHiredOperator_User | GetSeveralNodesWithConcreteAndAbstract_justHiredOperator_$$other;
 
 export type GetSeveralNodesWithConcreteAndAbstract_someNetwork_Network = {
-  __typename: "Network";
-  cidr: string;
-  id: string;
-  ipv6Cidr: string | null;
+  readonly __typename: "Network";
+  readonly cidr: string;
+  readonly id: string;
+  readonly ipv6Cidr: string | null;
 };
 
 export type GetSeveralNodesWithConcreteAndAbstract_someNetwork_$$other = {
-  __typename: "Host" | "User";
-  id: string;
+  readonly __typename: "Host" | "User";
+  readonly id: string;
 };
 
 export type GetSeveralNodesWithConcreteAndAbstract_someNetwork = GetSeveralNodesWithConcreteAndAbstract_someNetwork_Network | GetSeveralNodesWithConcreteAndAbstract_someNetwork_$$other;
 
 export type GetSeveralNodesWithConcreteAndAbstract = {
-  justHiredOperator: GetSeveralNodesWithConcreteAndAbstract_justHiredOperator | null;
-  someNetwork: GetSeveralNodesWithConcreteAndAbstract_someNetwork | null;
+  readonly justHiredOperator: GetSeveralNodesWithConcreteAndAbstract_justHiredOperator | null;
+  readonly someNetwork: GetSeveralNodesWithConcreteAndAbstract_someNetwork | null;
 };

--- a/tests/fixtures/typescript/complex/interface/compile_interface_concrete_only/__generated__/GetByNodeConcreteOnly.ts
+++ b/tests/fixtures/typescript/complex/interface/compile_interface_concrete_only/__generated__/GetByNodeConcreteOnly.ts
@@ -1,6 +1,6 @@
 export type GetByNodeConcreteOnly_desiredUser_User = {
-  email: string;
-  firstName: string;
+  readonly email: string;
+  readonly firstName: string;
 };
 
 export type GetByNodeConcreteOnly_desiredUser_$$other = {
@@ -10,5 +10,5 @@ export type GetByNodeConcreteOnly_desiredUser_$$other = {
 export type GetByNodeConcreteOnly_desiredUser = GetByNodeConcreteOnly_desiredUser_User | GetByNodeConcreteOnly_desiredUser_$$other;
 
 export type GetByNodeConcreteOnly = {
-  desiredUser: GetByNodeConcreteOnly_desiredUser | null;
+  readonly desiredUser: GetByNodeConcreteOnly_desiredUser | null;
 };

--- a/tests/fixtures/typescript/complex/interface/compile_interface_with_typename/__generated__/GetByNodeWithInterface.ts
+++ b/tests/fixtures/typescript/complex/interface/compile_interface_with_typename/__generated__/GetByNodeWithInterface.ts
@@ -1,22 +1,22 @@
 export type GetByNodeWithInterface_network123_Network_hosts = {
-  totalCount: number;
+  readonly totalCount: number;
 };
 
 export type GetByNodeWithInterface_network123_Network = {
-  __typename: "Network";
-  another: "Network";
-  as: "Network";
-  cidr: string;
-  hosts: GetByNodeWithInterface_network123_Network_hosts;
+  readonly __typename: "Network";
+  readonly another: "Network";
+  readonly as: "Network";
+  readonly cidr: string;
+  readonly hosts: GetByNodeWithInterface_network123_Network_hosts;
 };
 
 export type GetByNodeWithInterface_network123_$$other = {
-  __typename: "Host" | "User";
-  as: "Host" | "User";
+  readonly __typename: "Host" | "User";
+  readonly as: "Host" | "User";
 };
 
 export type GetByNodeWithInterface_network123 = GetByNodeWithInterface_network123_Network | GetByNodeWithInterface_network123_$$other;
 
 export type GetByNodeWithInterface = {
-  network123: GetByNodeWithInterface_network123 | null;
+  readonly network123: GetByNodeWithInterface_network123 | null;
 };

--- a/tests/fixtures/typescript/complex/union/compile_union_with_abstract_and_concrete_types/__generated__/GetTagsForHost.ts
+++ b/tests/fixtures/typescript/complex/union/compile_union_with_abstract_and_concrete_types/__generated__/GetTagsForHost.ts
@@ -1,25 +1,25 @@
 export type GetTagsForHost_host_tags_BooleanTag = {
-  __typename: "BooleanTag";
-  name: string;
+  readonly __typename: "BooleanTag";
+  readonly name: string;
   /**
    * If true, this boolean tag has inverted meaning
    */
-  not: boolean;
-  timeToLiveMs: number;
+  readonly not: boolean;
+  readonly timeToLiveMs: number;
 };
 
 export type GetTagsForHost_host_tags_$$other = {
-  __typename: "JSONTag" | "KeyValueTag";
-  timeToLiveMs: number;
+  readonly __typename: "JSONTag" | "KeyValueTag";
+  readonly timeToLiveMs: number;
 };
 
 export type GetTagsForHost_host_tags = GetTagsForHost_host_tags_BooleanTag | GetTagsForHost_host_tags_$$other;
 
 export type GetTagsForHost_host = {
-  id: string;
-  tags: GetTagsForHost_host_tags[];
+  readonly id: string;
+  readonly tags: GetTagsForHost_host_tags[];
 };
 
 export type GetTagsForHost = {
-  host: GetTagsForHost_host | null;
+  readonly host: GetTagsForHost_host | null;
 };

--- a/tests/fixtures/typescript/complex/union/compile_union_with_abstract_only/__generated__/GetTagsForNetwork.ts
+++ b/tests/fixtures/typescript/complex/union/compile_union_with_abstract_only/__generated__/GetTagsForNetwork.ts
@@ -1,24 +1,24 @@
 export type GetTagsForNetwork_network_tags_author_tags = {
-  timeToLiveMs: number;
+  readonly timeToLiveMs: number;
 };
 
 export type GetTagsForNetwork_network_tags_author = {
-  __typename: "User";
-  id: string;
-  tags: GetTagsForNetwork_network_tags_author_tags[];
+  readonly __typename: "User";
+  readonly id: string;
+  readonly tags: GetTagsForNetwork_network_tags_author_tags[];
 };
 
 export type GetTagsForNetwork_network_tags = {
-  __typename: "BooleanTag" | "JSONTag" | "KeyValueTag";
-  author: GetTagsForNetwork_network_tags_author;
-  timeToLiveMs: number;
+  readonly __typename: "BooleanTag" | "JSONTag" | "KeyValueTag";
+  readonly author: GetTagsForNetwork_network_tags_author;
+  readonly timeToLiveMs: number;
 };
 
 export type GetTagsForNetwork_network = {
-  id: string;
-  tags: GetTagsForNetwork_network_tags[];
+  readonly id: string;
+  readonly tags: GetTagsForNetwork_network_tags[];
 };
 
 export type GetTagsForNetwork = {
-  network: GetTagsForNetwork_network | null;
+  readonly network: GetTagsForNetwork_network | null;
 };

--- a/tests/fixtures/typescript/complex/union/compile_union_with_concrete_only/__generated__/GetTagsForCurrentOperator.ts
+++ b/tests/fixtures/typescript/complex/union/compile_union_with_concrete_only/__generated__/GetTagsForCurrentOperator.ts
@@ -1,34 +1,34 @@
 export type GetTagsForCurrentOperator_operator_tags_BooleanTag = {
-  __typename: "BooleanTag";
-  name: string;
+  readonly __typename: "BooleanTag";
+  readonly name: string;
   /**
    * If true, this boolean tag has inverted meaning
    */
-  not: boolean;
+  readonly not: boolean;
   /**
    * If true, this boolean tag has inverted meaning
    */
-  notNot: boolean;
+  readonly notNot: boolean;
 };
 
 export type GetTagsForCurrentOperator_operator_tags_JSONTag = {
-  __typename: "JSONTag";
-  content: any;
+  readonly __typename: "JSONTag";
+  readonly content: any;
 };
 
 export type GetTagsForCurrentOperator_operator_tags_KeyValueTag = {
-  __typename: "KeyValueTag";
-  key: string;
-  value: string;
+  readonly __typename: "KeyValueTag";
+  readonly key: string;
+  readonly value: string;
 };
 
 export type GetTagsForCurrentOperator_operator_tags = GetTagsForCurrentOperator_operator_tags_BooleanTag | GetTagsForCurrentOperator_operator_tags_JSONTag | GetTagsForCurrentOperator_operator_tags_KeyValueTag;
 
 export type GetTagsForCurrentOperator_operator = {
-  email: string;
-  tags: GetTagsForCurrentOperator_operator_tags[];
+  readonly email: string;
+  readonly tags: GetTagsForCurrentOperator_operator_tags[];
 };
 
 export type GetTagsForCurrentOperator = {
-  operator: GetTagsForCurrentOperator_operator | null;
+  readonly operator: GetTagsForCurrentOperator_operator | null;
 };

--- a/tests/fixtures/typescript/complex/union/compile_union_with_fragments/__generated__/MyResourceTag.ts
+++ b/tests/fixtures/typescript/complex/union/compile_union_with_fragments/__generated__/MyResourceTag.ts
@@ -1,43 +1,43 @@
 export type MyResourceTag_BooleanTag_author = {
-  email: string;
-  id: string;
+  readonly email: string;
+  readonly id: string;
 };
 
 export type MyResourceTag_BooleanTag = {
-  __typename: "BooleanTag";
-  author: MyResourceTag_BooleanTag_author;
-  name: string;
+  readonly __typename: "BooleanTag";
+  readonly author: MyResourceTag_BooleanTag_author;
+  readonly name: string;
   /**
    * If true, this boolean tag has inverted meaning
    */
-  not: boolean;
-  timeToLiveMs: number;
+  readonly not: boolean;
+  readonly timeToLiveMs: number;
 };
 
 export type MyResourceTag_KeyValueTag_author = {
-  email: string;
-  id: string;
+  readonly email: string;
+  readonly id: string;
 };
 
 export type MyResourceTag_KeyValueTag = {
-  __typename: "KeyValueTag";
-  anotherKeyName: string;
-  author: MyResourceTag_KeyValueTag_author;
-  key: string;
-  keyTTL: number;
-  timeToLiveMs: number;
-  value: string;
+  readonly __typename: "KeyValueTag";
+  readonly anotherKeyName: string;
+  readonly author: MyResourceTag_KeyValueTag_author;
+  readonly key: string;
+  readonly keyTTL: number;
+  readonly timeToLiveMs: number;
+  readonly value: string;
 };
 
 export type MyResourceTag_$$other_author = {
-  email: string;
-  id: string;
+  readonly email: string;
+  readonly id: string;
 };
 
 export type MyResourceTag_$$other = {
-  __typename: "JSONTag";
-  author: MyResourceTag_$$other_author;
-  timeToLiveMs: number;
+  readonly __typename: "JSONTag";
+  readonly author: MyResourceTag_$$other_author;
+  readonly timeToLiveMs: number;
 };
 
 export type MyResourceTag = MyResourceTag_BooleanTag | MyResourceTag_KeyValueTag | MyResourceTag_$$other;

--- a/tests/fixtures/typescript/complex/union/compile_union_with_typenames/__generated__/GetTagTypeNamesForHost.ts
+++ b/tests/fixtures/typescript/complex/union/compile_union_with_typenames/__generated__/GetTagTypeNamesForHost.ts
@@ -1,27 +1,27 @@
 export type GetTagTypeNamesForHost_host_tags_BooleanTag = {
-  __typename: "BooleanTag";
-  as: "BooleanTag";
-  name: string;
+  readonly __typename: "BooleanTag";
+  readonly as: "BooleanTag";
+  readonly name: string;
 };
 
 export type GetTagTypeNamesForHost_host_tags_JSONTag = {
-  __typename: "JSONTag";
-  as: "JSONTag";
-  content: any;
-  typername: "JSONTag";
+  readonly __typename: "JSONTag";
+  readonly as: "JSONTag";
+  readonly content: any;
+  readonly typername: "JSONTag";
 };
 
 export type GetTagTypeNamesForHost_host_tags_$$other = {
-  __typename: "KeyValueTag";
-  as: "KeyValueTag";
+  readonly __typename: "KeyValueTag";
+  readonly as: "KeyValueTag";
 };
 
 export type GetTagTypeNamesForHost_host_tags = GetTagTypeNamesForHost_host_tags_BooleanTag | GetTagTypeNamesForHost_host_tags_JSONTag | GetTagTypeNamesForHost_host_tags_$$other;
 
 export type GetTagTypeNamesForHost_host = {
-  tags: GetTagTypeNamesForHost_host_tags[];
+  readonly tags: GetTagTypeNamesForHost_host_tags[];
 };
 
 export type GetTagTypeNamesForHost = {
-  host: GetTagTypeNamesForHost_host | null;
+  readonly host: GetTagTypeNamesForHost_host | null;
 };

--- a/tests/fixtures/typescript/enumeration/compile_with_global_types/__generated__/WithGlobals.ts
+++ b/tests/fixtures/typescript/enumeration/compile_with_global_types/__generated__/WithGlobals.ts
@@ -1,17 +1,17 @@
 import type { OperatingSystem } from "__generated__/globalTypes";
 
 export type WithGlobals_operator_personalHost = {
-  id: string;
-  operatingSystem: OperatingSystem;
+  readonly id: string;
+  readonly operatingSystem: OperatingSystem;
 };
 
 export type WithGlobals_operator = {
   /**
    * A user's personal device
    */
-  personalHost: WithGlobals_operator_personalHost;
+  readonly personalHost: WithGlobals_operator_personalHost;
 };
 
 export type WithGlobals = {
-  operator: WithGlobals_operator | null;
+  readonly operator: WithGlobals_operator | null;
 };

--- a/tests/fixtures/typescript/enumeration/compile_with_global_types/__generated__/globalTypes.ts
+++ b/tests/fixtures/typescript/enumeration/compile_with_global_types/__generated__/globalTypes.ts
@@ -3,6 +3,6 @@
  */
 export enum OperatingSystem {
   ARCH_LINUX = "ARCH_LINUX",
-  UBUNTU_LINUX = "UBUNTU_LINUX",
   FREEBSD = "FREEBSD",
+  UBUNTU_LINUX = "UBUNTU_LINUX",
 }

--- a/tests/fixtures/typescript/field/compile_custom_scalar_any/__generated__/CustomScalar.ts
+++ b/tests/fixtures/typescript/field/compile_custom_scalar_any/__generated__/CustomScalar.ts
@@ -2,17 +2,17 @@ export type CustomScalar_operator_activity = {
   /**
    * User's last time successfully authenticating
    */
-  login: any | null;
+  readonly login: any | null;
 };
 
 export type CustomScalar_operator = {
   /**
    * User's activity timestamps
    */
-  activity: CustomScalar_operator_activity;
-  id: string;
+  readonly activity: CustomScalar_operator_activity;
+  readonly id: string;
 };
 
 export type CustomScalar = {
-  operator: CustomScalar_operator | null;
+  readonly operator: CustomScalar_operator | null;
 };

--- a/tests/fixtures/typescript/field/compile_custom_scalar_with_default_names/__generated__/CustomScalar.ts
+++ b/tests/fixtures/typescript/field/compile_custom_scalar_with_default_names/__generated__/CustomScalar.ts
@@ -2,17 +2,17 @@ export type CustomScalar_operator_activity = {
   /**
    * User's last time successfully authenticating
    */
-  login: ISO8601 | null;
+  readonly login: ISO8601 | null;
 };
 
 export type CustomScalar_operator = {
   /**
    * User's activity timestamps
    */
-  activity: CustomScalar_operator_activity;
-  id: string;
+  readonly activity: CustomScalar_operator_activity;
+  readonly id: string;
 };
 
 export type CustomScalar = {
-  operator: CustomScalar_operator | null;
+  readonly operator: CustomScalar_operator | null;
 };

--- a/tests/fixtures/typescript/field/compile_custom_scalar_with_prefixed_names/__generated__/CustomScalar.ts
+++ b/tests/fixtures/typescript/field/compile_custom_scalar_with_prefixed_names/__generated__/CustomScalar.ts
@@ -2,17 +2,17 @@ export type CustomScalar_operator_activity = {
   /**
    * User's last time successfully authenticating
    */
-  login: PrefixISO8601 | null;
+  readonly login: PrefixISO8601 | null;
 };
 
 export type CustomScalar_operator = {
   /**
    * User's activity timestamps
    */
-  activity: CustomScalar_operator_activity;
-  id: string;
+  readonly activity: CustomScalar_operator_activity;
+  readonly id: string;
 };
 
 export type CustomScalar = {
-  operator: CustomScalar_operator | null;
+  readonly operator: CustomScalar_operator | null;
 };

--- a/tests/fixtures/typescript/field/compile_fields_with_deprecation_marker/__generated__/WithDeprecatedFields.ts
+++ b/tests/fixtures/typescript/field/compile_fields_with_deprecation_marker/__generated__/WithDeprecatedFields.ts
@@ -1,16 +1,16 @@
 export type WithDeprecatedFields_operator = {
-  id: string;
+  readonly id: string;
   /**
    * User's last time logging in
    * @deprecated
    */
-  lastLogin: any | null;
+  readonly lastLogin: any | null;
   /**
    * @deprecated
    */
-  publicRSAKey: string;
+  readonly publicRSAKey: string;
 };
 
 export type WithDeprecatedFields = {
-  operator: WithDeprecatedFields_operator | null;
+  readonly operator: WithDeprecatedFields_operator | null;
 };

--- a/tests/fixtures/typescript/field/compile_fields_with_recursive_list_types/__generated__/WithRecursiveListFields.ts
+++ b/tests/fixtures/typescript/field/compile_fields_with_recursive_list_types/__generated__/WithRecursiveListFields.ts
@@ -1,0 +1,9 @@
+export type WithRecursiveListFields_network = {
+  readonly hostIdGroups: (string[])[];
+  readonly hostIdTopology: (((((string | null)[] | null) | null)[] | null) | null)[] | null;
+  readonly id: string;
+};
+
+export type WithRecursiveListFields = {
+  readonly network: WithRecursiveListFields_network | null;
+};

--- a/tests/fixtures/typescript/field/compile_fields_with_recursive_list_types/with_recursive_lists_query.graphql
+++ b/tests/fixtures/typescript/field/compile_fields_with_recursive_list_types/with_recursive_lists_query.graphql
@@ -1,0 +1,9 @@
+query WithRecursiveListFields {
+  network(id: "networkWithTopology") {
+    id
+    # A list of lists
+    hostIdGroups
+    # A list of list of lists of nulls :)
+    hostIdTopology
+  }
+}

--- a/tests/fixtures/typescript/field/compile_fields_without_readonly_marker/__generated__/NoReadOnlyPlease.ts
+++ b/tests/fixtures/typescript/field/compile_fields_without_readonly_marker/__generated__/NoReadOnlyPlease.ts
@@ -1,0 +1,15 @@
+export type NoReadOnlyPlease_operator_personalHost = {
+  numCpus: number;
+};
+
+export type NoReadOnlyPlease_operator = {
+  id: string;
+  /**
+   * A user's personal device
+   */
+  personalHost: NoReadOnlyPlease_operator_personalHost;
+};
+
+export type NoReadOnlyPlease = {
+  operator: NoReadOnlyPlease_operator | null;
+};

--- a/tests/fixtures/typescript/field/compile_fields_without_readonly_marker/with_deprecated_query.graphql
+++ b/tests/fixtures/typescript/field/compile_fields_without_readonly_marker/with_deprecated_query.graphql
@@ -1,0 +1,8 @@
+query NoReadOnlyPlease {
+  operator {
+    id
+    personalHost {
+      numCpus
+    }
+  }
+}

--- a/tests/fixtures/typescript/variable/compile_mutation_with_inputs_including_lists/__generated__/AddHostToManyNetworks.ts
+++ b/tests/fixtures/typescript/variable/compile_mutation_with_inputs_including_lists/__generated__/AddHostToManyNetworks.ts
@@ -1,20 +1,20 @@
 import type { AttachHostToNetworksInput } from "__generated__/globalTypes";
 
 export type AddHostToManyNetworks_attachHostToNetworks_host_networks = {
-  id: string;
+  readonly id: string;
 };
 
 export type AddHostToManyNetworks_attachHostToNetworks_host = {
-  id: string;
-  networks: AddHostToManyNetworks_attachHostToNetworks_host_networks[];
+  readonly id: string;
+  readonly networks: AddHostToManyNetworks_attachHostToNetworks_host_networks[];
 };
 
 export type AddHostToManyNetworks_attachHostToNetworks = {
-  host: AddHostToManyNetworks_attachHostToNetworks_host;
+  readonly host: AddHostToManyNetworks_attachHostToNetworks_host;
 };
 
 export type AddHostToManyNetworks = {
-  attachHostToNetworks: AddHostToManyNetworks_attachHostToNetworks;
+  readonly attachHostToNetworks: AddHostToManyNetworks_attachHostToNetworks;
 };
 
 export type AddHostToManyNetworksVariables = {

--- a/tests/fixtures/typescript/variable/compile_mutation_with_variables/__generated__/SimpleProvision.ts
+++ b/tests/fixtures/typescript/variable/compile_mutation_with_variables/__generated__/SimpleProvision.ts
@@ -1,18 +1,18 @@
 import type { ProvisionHostInput } from "__generated__/globalTypes";
 
 export type SimpleProvision_provisionHost_host = {
-  id: string;
+  readonly id: string;
 };
 
 export type SimpleProvision_provisionHost = {
-  host: SimpleProvision_provisionHost_host;
+  readonly host: SimpleProvision_provisionHost_host;
 };
 
 export type SimpleProvision = {
   /**
    * Null return means it failed
    */
-  provisionHost: SimpleProvision_provisionHost | null;
+  readonly provisionHost: SimpleProvision_provisionHost | null;
 };
 
 export type SimpleProvisionVariables = {

--- a/tests/fixtures/typescript/variable/compile_mutation_with_variables/__generated__/globalTypes.ts
+++ b/tests/fixtures/typescript/variable/compile_mutation_with_variables/__generated__/globalTypes.ts
@@ -3,8 +3,8 @@
  */
 export enum OperatingSystem {
   ARCH_LINUX = "ARCH_LINUX",
-  UBUNTU_LINUX = "UBUNTU_LINUX",
   FREEBSD = "FREEBSD",
+  UBUNTU_LINUX = "UBUNTU_LINUX",
 }
 
 export type ProvisionHostInput = {

--- a/tests/fixtures/typescript/variable/compile_query_with_variables/__generated__/SimpleGetNetwork.ts
+++ b/tests/fixtures/typescript/variable/compile_query_with_variables/__generated__/SimpleGetNetwork.ts
@@ -1,10 +1,10 @@
 export type SimpleGetNetwork_network = {
-  cidr: string;
-  id: string;
+  readonly cidr: string;
+  readonly id: string;
 };
 
 export type SimpleGetNetwork = {
-  network: SimpleGetNetwork_network | null;
+  readonly network: SimpleGetNetwork_network | null;
 };
 
 export type SimpleGetNetworkVariables = {

--- a/tests/helpers/cmd.rs
+++ b/tests/helpers/cmd.rs
@@ -10,8 +10,7 @@ use std::process::{Command, Stdio};
 
 const DEFAULT_QLCRC_JSON_PATH: &str = ".qlcrc.json";
 const FIXTURE_ROOT_PATH: &str = "tests/fixtures";
-const TS_FILE_HEADER: &str = "/* tslint:disable */
-/* eslint-disable */
+const TS_FILE_HEADER: &str = "/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 ";

--- a/tests/typescript/field.rs
+++ b/tests/typescript/field.rs
@@ -30,3 +30,11 @@ fn compile_fields_with_deprecation_marker() {
         .with_fixture_directory("typescript/field/compile_fields_with_deprecation_marker")
         .run_for_success();
 }
+
+#[test]
+fn compile_fields_without_readonly_marker() {
+    TestCommandHarness::default()
+        .with_arg("--disable-readonly-types")
+        .with_fixture_directory("typescript/field/compile_fields_without_readonly_marker")
+        .run_for_success();
+}

--- a/tests/typescript/field.rs
+++ b/tests/typescript/field.rs
@@ -25,6 +25,13 @@ fn compile_custom_scalar_with_prefixed_names() {
 }
 
 #[test]
+fn compile_fields_with_recursive_list_types() {
+    TestCommandHarness::default()
+        .with_fixture_directory("typescript/field/compile_fields_with_recursive_list_types")
+        .run_for_success();
+}
+
+#[test]
 fn compile_fields_with_deprecation_marker() {
     TestCommandHarness::default()
         .with_fixture_directory("typescript/field/compile_fields_with_deprecation_marker")


### PR DESCRIPTION
* Remove `tslint:disable` comments from output. This linter is long deprecated and users can switch to their own ignore if need be.
* Add support for marking properties as `readonly` and make this the default
* Sort enum variants for more deterministic and discernable output
* Better support for recursive list types (list of lists, etc)

Technically first two bullet points are breaking compability changes so I'll release these as a major semver version later. 
