### PR TITLE
Add Security Checksums to NPM Package Post-install

### DIFF
--- a/.circleci/bin/make-github-release.sh
+++ b/.circleci/bin/make-github-release.sh
@@ -10,9 +10,10 @@ mkdir -p "$ARCHIVES_DIR"
 for PLATFORM in "${RELEASE_PLATFORMS[@]}"
 do
   cd "$CIRCLE_WORKING_DIRECTORY/target/$PLATFORM/release"
-  tar czf "qlc-$QLC_VERSION-$PLATFORM.tar.gz" qlc
-  mv "qlc-$QLC_VERSION-$PLATFORM.tar.gz" "$ARCHIVES_DIR"
+  tar czf "$ARCHIVES_DIR/qlc-$QLC_VERSION-$PLATFORM.tar.gz" qlc
 done
+
+sha256sum "$ARCHIVES_DIR"/* | tee "$ARCHIVES_DIR/checksums.txt"
 
 echo "*** Making release out of $ARCHIVES_DIR ***"
 ls -l "$ARCHIVES_DIR"

--- a/.circleci/bin/make-npm-release.sh
+++ b/.circleci/bin/make-npm-release.sh
@@ -2,10 +2,17 @@
 set -eo pipefail
 
 . "$CIRCLE_WORKING_DIRECTORY/.circleci/bin/get-version-from-binary.sh"
+. "$CIRCLE_WORKING_DIRECTORY/.circleci/bin/get-release-platforms.sh"
 
 cd "$CIRCLE_WORKING_DIRECTORY/pkg/npm"
 
 sed -i "s/@QLC_VERSION@/$QLC_VERSION/g" package.json
+for PLATFORM in "${RELEASE_PLATFORMS[@]}"
+do
+  CHECKSUM_LINE="$(grep "qlc-$QLC_VERSION-$PLATFORM.tar.gz" "$CIRCLE_WORKING_DIRECTORY/archives/checksums.txt")"
+  CHECKSUM_LINE_SPLIT=($CHECKSUM_LINE)
+  sed -i "s/@${PLATFORM}_CHECKSUM@/${CHECKSUM_LINE_SPLIT[0]}/g" package.json
+done
 
 NPM_RELEASE_ARGS=(
   --new-version "$QLC_VERSION"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,10 @@ jobs:
       - run:
           name: Making GitHub release
           command: ./.circleci/bin/make-github-release.sh
+      - persist_to_workspace:
+          root: /root/notarize
+          paths:
+            - qlc/archives/checksums.txt
 
   create_npm_release:
     executor: node_env

--- a/pkg/npm/package.json
+++ b/pkg/npm/package.json
@@ -14,6 +14,11 @@
     "qlc": "bin/qlc",
     "qlc-download-schema": "bin/qlc-download-schema"
   },
+  "checksumConfig": {
+    "aarch64-apple-darwin": "@aarch64-apple-darwin_CHECKSUM@",
+    "x86_64-apple-darwin": "@x86_64-apple-darwin_CHECKSUM@",
+    "x86_64-unknown-linux-musl": "@x86_64-unknown-linux-musl_CHECKSUM@"
+  },
   "files": [
     "bin",
     "lib"


### PR DESCRIPTION
More security: we now embed checksums into the NPM package (which will be in turn checksumed by `yarn`/`npm` when users install it) and then use these integrity checks on binary tarballs.