### PR TITLE
Add Nix Development Environment and Packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,117 +1,100 @@
 version: 2.1
 
-commands:
-  attach_made_workspace:
-    description: Attach workspace generated files from another job
-    steps:
-      - attach_workspace:
-          at: /root/notarize
+in_nix_shell: &in_nix_shell
+  shell: /usr/bin/env nix develop --command bash -eo pipefail
 
+commands:
+  configure_nix:
+    description: Configure nix for use in workflows
+    steps:
+      - run:
+          name: Editing nix.conf
+          command: |
+            echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf
+            echo 'cores = 4' >> /etc/nix/nix.conf
+        
 executors:
-  default_rust_compiler:
+  default_nix_devenv:
     docker:
-      - image: rust:1.73.0-bookworm
-    working_directory: /root/notarize/qlc
+      - image: nixos/nix:2.21.1
+    working_directory: /opt/qlc
     environment:
-      CARGO_HOME: /root/notarize/qlc/.cargo
+      CARGO_HOME: /opt/qlc/.cargo
 
   cross_compiling_host:
     docker:
       - image: notarize/cross-rust:1.73.0-bookworm
-    working_directory: /root/notarize/qlc
+    working_directory: /opt/qlc
     environment:
-      CARGO_HOME: /root/notarize/qlc/.cargo
+      CARGO_HOME: /opt/qlc/.cargo
 
   github_api_client:
     docker:
       - image: notarize/github-api-client:ghr-0.16.0
-    working_directory: /root/notarize/qlc
+    working_directory: /opt/qlc
 
   node_env:
     docker:
       - image: cimg/node:18.16.1
         user: root
-    working_directory: /root/notarize/qlc
+    working_directory: /opt/qlc
 
 jobs:
-  test_schema_init:
-    executor: node_env
+  static_analysis:
+    executor: default_nix_devenv
     steps:
       - checkout
+      - configure_nix
       - run:
-          name: Building schema
-          command: |
-            cd tests/fixtures/schema_generation
-            yarn install --frozen-lockfile
-            yarn run build
-      - persist_to_workspace:
-          root: /root/notarize
-          paths:
-            - qlc/tests/fixtures/schema_generation/output
-
-  cargo_init:
-    executor: default_rust_compiler
-    steps:
-      - checkout
+          name: Priming nix shell
+          command: nix build -L --no-link --print-out-paths .#devShells.x86_64-linux.default
       - restore_cache:
           keys:
-            - cargo-cache-v2-{{ checksum "Cargo.lock" }}
-            - cargo-cache-v2-
+            - cargo-cache-v3-{{ checksum "Cargo.lock" }}
+            - cargo-cache-v3-
       - run:
-          name: Building
-          command: cargo build --all-targets --all-features
+          name: Linting
+          command: just lint
+          <<: *in_nix_shell
+      - run:
+          name: Formatting
+          command: |
+            cargo fmt --all -- --check
+            nix fmt -- --check .
+          when: always
+          <<: *in_nix_shell
+      - run:
+          name: Testing
+          command: |
+            just build-test-schema
+            just test -- --test-threads=7
+          when: always
+          <<: *in_nix_shell
       - save_cache:
+          key: cargo-cache-v3-{{ checksum "Cargo.lock" }}
           paths:
             - /usr/local/cargo/registry
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
+            - target/release/.fingerprint
+            - target/release/build
+            - target/release/deps
             - .cargo
-          key: cargo-cache-v2-{{ checksum "Cargo.lock" }}
       - persist_to_workspace:
-          root: /root/notarize
+          root: /opt
           paths:
             - qlc
-
-  fmt:
-    executor: default_rust_compiler
-    steps:
-      - attach_made_workspace
-      - run:
-          name: Getting rustfmt
-          command: rustup component add rustfmt
-      - run:
-          name: Checking formating
-          command: cargo fmt --all -- --check
-
-  lint:
-    executor: default_rust_compiler
-    steps:
-      - attach_made_workspace
-      - run:
-          name: Getting clippy
-          command: rustup component add clippy
-      - run:
-          name: Linting
-          command: cargo clippy --all-targets --all-features -- -D warnings
-
-  test:
-    executor: default_rust_compiler
-    steps:
-      - attach_made_workspace
-      - run:
-          name: Testing
-          command: cargo test -- --test-threads=7
 
   build_release_bin:
     executor: cross_compiling_host
     steps:
-      - attach_made_workspace
+      - attach_workspace: { at: /opt }
       - run:
           name: Building all release targets
           command: ./.circleci/bin/build-release-binary.sh
       - persist_to_workspace:
-          root: /root/notarize
+          root: /opt
           paths:
             - qlc/target/x86_64-apple-darwin/release
             - qlc/target/aarch64-apple-darwin/release
@@ -121,19 +104,19 @@ jobs:
   create_github_release:
     executor: github_api_client
     steps:
-      - attach_made_workspace
+      - attach_workspace: { at: /opt }
       - run:
           name: Making GitHub release
           command: ./.circleci/bin/make-github-release.sh
       - persist_to_workspace:
-          root: /root/notarize
+          root: /opt
           paths:
             - qlc/archives/checksums.txt
 
   create_npm_release:
     executor: node_env
     steps:
-      - attach_made_workspace
+      - attach_workspace: { at: /opt }
       - run:
           name: Configuring NPM token
           command: |
@@ -147,43 +130,11 @@ workflows:
   version: 2
   Everything:
     jobs:
-      - cargo_init:
-          filters:
-            branches:
-              ignore: main
-
-      - test_schema_init:
-          filters:
-            branches:
-              ignore: main
-
-      - test:
-          requires:
-            - cargo_init
-            - test_schema_init
-          filters:
-            branches:
-              ignore: main
-
-      - lint:
-          requires:
-            - cargo_init
-          filters:
-            branches:
-              ignore: main
-
-      - fmt:
-          requires:
-            - cargo_init
-          filters:
-            branches:
-              ignore: main
+      - static_analysis
 
       - build_release_bin:
           requires:
-            - test
-            - lint
-            - fmt
+            - static_analysis
           filters:
             branches:
               only:

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
+fi
+
+watch_file ./shell.nix
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+result*

--- a/README.md
+++ b/README.md
@@ -125,41 +125,40 @@ measured runtime. The directory in question has 4523 files and 534 `.graphql` fi
 
 ### Development
 
-Development, compiling, testing, etc require a relatively recent version of `rustc` and `cargo`.
-`node` and `yarn` are used for some tasks, like packaging the NPM release (see `pkg/npm`), as well
-as creating a mock schema JSON for usage with `cargo test`.
+To develop qlc, one needs a working `cargo`, `rustc`, `node`, and `yarn` installation. The repository
+provides this via a Nix shell (`shell.nix`) for ease. `node` and `yarn` are used for some tasks, like
+packaging the NPM release (see `pkg/npm`), as well as creating a mock schema JSON for testing.
 
 Here are a number of reminders for useful commands, most of which also are executed in CI:
 
-```sh
-# Formatting
-cargo fmt --all
+```shell
+# If using the nix shell, the `just` command runner can be utilized to list recipes
+just
 
-# Linting
-cargo clippy --all-targets --all-features -- -D warnings
+# Static tools
+just lint
+just format
+
+# Benchmarking on a `src` directory (using hyperfine)
+hyperfine --warmup 2 -p 'find src -name "*.graphql.d.ts" -type f -exec rm {} +' '../qlc/target/release/qlc src'
 
 # Testing
-## Test Setup, turning tests/fixtures/schema_generation/schema.graphl into a
-## usable tests/fixtures/schema_generation/output/schema.json
-yarn --cwd tests/fixtures/schema_generation install --frozen-lockfile
-yarn --cwd tests/fixtures/schema_generation run build
+## Test Setup
+just build-test-schema
 
 ## Run all tests
-cargo test
+just test
 
 ## Run matching test
-cargo test union_with_typename
+just test union_with_typename
 
 ## Instruct cargo test not to capture stdout/stderr so that one can see `dbg!()` output, etc.
-cargo test -- --nocapture
+just test -- --nocapture
 
 ## Instruct the test harness not to delete temporary directories created during testing for debugging
-KEEP_TEST_TEMPDIRS=t cargo test
+KEEP_TEST_TEMPDIRS=t just test
 
 ## Instruct the test harness overwrite expected fixtures with actual output -- useful for large swath compiler output changes
 ## Warning: will change repo files on disk
-OVERWRITE_FIXTURES=t cargo test
-
-# Benchmarking on a `src` directory
-hyperfine --warmup 2 -p 'find src -name "*.graphql.d.ts" -type f -exec rm {} +' '../qlc/target/release/qlc src'
+OVERWRITE_FIXTURES=t just test
 ```

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, rustPlatform
+, yarn
+, prefetch-yarn-deps
+, fetchYarnDeps
+}:
+let
+  inherit (lib) fileset;
+  lockFile = ./Cargo.lock;
+  cargoFile = ./Cargo.toml;
+  cargoToml = builtins.fromTOML (builtins.readFile cargoFile);
+
+  yarnLock = ./tests/fixtures/schema_generation/yarn.lock;
+  checkYarnDeps = fetchYarnDeps {
+    name = "qlc-test-schema-generation-yarn-deps";
+    inherit yarnLock;
+    hash = "sha256-1KrnYGzkAE1f21q93DpknkHgq8l0V41MvoDeQFrFavM=";
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "qlc";
+  inherit (cargoToml.package) version;
+
+  src = fileset.toSource {
+    root = ./.;
+    fileset = fileset.intersection
+      (fileset.gitTracked ./.)
+      (fileset.unions [ lockFile cargoFile ./src ./tests ]);
+  };
+  cargoLock = { inherit lockFile; };
+
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+    pushd tests/fixtures/schema_generation
+
+    yarn config set yarn-offline-mirror "${checkYarnDeps}"
+    fixup-yarn-lock yarn.lock
+    yarn install --offline --frozen-lockfile --no-progress --non-interactive
+
+    yarn run build
+
+    popd
+  '';
+  nativeCheckInputs = [ prefetch-yarn-deps yarn checkYarnDeps ];
+
+  meta = {
+    description = "A fun codegenerator for GraphQL clients.";
+    homepage = "https://github.com/notarize/qlc";
+    license = lib.licenses.mit;
+    mainProgram = "qlc";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+
+      eachSystem = flakeFunc: builtins.foldl'
+        (accum: system: lib.recursiveUpdate accum (flakeFunc system))
+        { }
+        [
+          "aarch64-darwin"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "x86_64-linux"
+        ];
+    in
+    eachSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        defaultQlcPackage = pkgs.callPackage (import ./default.nix) { };
+      in
+      {
+        devShells.${system}.default = pkgs.callPackage (import ./shell.nix) { qlc = defaultQlcPackage; };
+
+        formatter.${system} = pkgs.nixpkgs-fmt;
+
+        packages.${system}.default = defaultQlcPackage;
+      }
+    );
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,52 @@
+{ mkShell
+, qlc
+, clippy
+, rustfmt
+, just
+, writeText
+, runCommand
+, makeBinaryWrapper
+}:
+let
+  justfile = writeText "qlc-justfile" ''
+    [private]
+    default:
+      @just --list --list-heading $'QLC recipes\n'
+
+    # Build the schema for cargo tests
+    build-test-schema:
+      @yarn --cwd tests/fixtures/schema_generation install --frozen-lockfile
+      # Turning tests/fixtures/schema_generation/schema.graphl into a usable tests/fixtures/schema_generation/output/schema.json
+      @yarn --cwd tests/fixtures/schema_generation run build
+    
+    # Run tests
+    test *args:
+      cargo test {{args}}
+
+    # Format source files
+    format:
+      cargo fmt --all
+      nix fmt
+
+    # Lint Rust source files
+    lint:
+      cargo clippy --all-targets --all-features -- -D warnings
+  '';
+  justWithConfig = runCommand
+    "qlc-wrapped-just"
+    { nativeBuildInputs = [ makeBinaryWrapper ]; }
+    ''
+      makeBinaryWrapper ${just}/bin/just $out/bin/just \
+        --add-flags '--justfile ${justfile}' \
+        --add-flags '--working-directory .'
+    '';
+in
+mkShell {
+  name = "qlc-devshell";
+  inputsFrom = [ qlc ];
+  packages = [
+    clippy
+    rustfmt
+    justWithConfig
+  ];
+}


### PR DESCRIPTION
This adds a convenient nix shell for development so users and CI don't have to manually manage cargo, rustc, yarn, etc. It does not (yet) use nix to build the releases since that requires more complicated cross compilation and I thought I would add this in a future PR.